### PR TITLE
Fix typo in comment

### DIFF
--- a/SSPullToRefreshView.h
+++ b/SSPullToRefreshView.h
@@ -21,7 +21,7 @@
 //    [self.pullToRefreshView finishLoading];
 // }
 // 
-// - (void)pullToRefreshViewShouldRefreshDidStartLoading:(SSPullToRefreshView *)view {
+// - (void)pullToRefreshViewDidStartLoading:(SSPullToRefreshView *)view {
 //    [self refresh];
 // }
 //


### PR DESCRIPTION
Fixes the pullToRefreshViewShouldRefreshDidStartLoading typo in the comment's example usage.
