### PR TITLE
fixed source reference in podspec

### DIFF
--- a/SSPullToRefresh.podspec
+++ b/SSPullToRefresh.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary   = 'Simple and highly customizable pull to refresh view.'
   s.homepage  = 'https://github.com/samsoffes/sspulltorefresh'
   s.author    = { 'Sam Soffes' => 'sam@samsoff.es' }
-  s.source    = { :git => 'https://github.com/samsoffes/sspulltorefresh.git', :commit => '1.0.1' }
+  s.source    = { :git => 'https://github.com/samsoffes/sspulltorefresh.git', :tag => '1.0.1' }
   s.license   = {
     :type => 'MIT',
     :file => 'LICENSE'


### PR DESCRIPTION
For referencing tag instead of commit as source we should use `:tag` instead of `:commit`.  In cocoapods spec repo I fixed it during merge. So it should be fixed only here.
