### PR TITLE
Taking top inset into consideration when detecting refresh

### DIFF
--- a/SSPullToRefreshView.m
+++ b/SSPullToRefreshView.m
@@ -106,7 +106,6 @@
 - (void)dealloc {
 	self.scrollView = nil;
 	self.delegate = nil;
-	dispatch_release(_animationSemaphore);
 }
 
 


### PR DESCRIPTION
I'm creating an table view that has a big clear Area in the top to show the background view. But after I set the contentInset, the pull to refresh view start to behave strange.  The view start to refresh after the content view show on screen, instead of after pull "over" the top.
