### PR TITLE
added time to 'Last Updated' message

### DIFF
--- a/SSPullToRefreshDefaultContentView.m
+++ b/SSPullToRefreshDefaultContentView.m
@@ -75,10 +75,14 @@
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
 		dateFormatter = [[NSDateFormatter alloc] init];
-		dateFormatter.dateStyle = NSDateFormatterLongStyle;
-		
+        dateFormatter.formatterBehavior = NSDateFormatterBehavior10_4;
+        dateFormatter.dateStyle = NSDateFormatterLongStyle;
+        dateFormatter.timeStyle = NSDateFormatterShortStyle;
 	});
-	_lastUpdatedAtLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [dateFormatter stringFromDate:date]];
+    NSDateComponents *components = [calendar components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit) 
+											   fromDate:self];
+	return [calendar dateFromComponents:components];
+	_lastUpdatedAtLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [dateFormatter stringForObjectValue:date]];
 }
 
 @end


### PR DESCRIPTION
I've used here `stringForObjectValue:` instead of `stringFromDate:`
because it's given as explanation of NSDateFormatter's class method
`localizedStringFromDate:dateStyle:timeStyle:` in apple docs.
FormatterBehavior I've also set as it given in that method.
[#11]
