### PR TITLE
feature: make the scrollView scroll to top and show the contentView

### DIFF
--- a/SSPullToRefreshView.m
+++ b/SSPullToRefreshView.m
@@ -224,6 +224,11 @@
 	// Update the content inset
 	_scrollView.contentInset = inset;
 
+	// If scrollView is on top, scroll again to the top (needed for scrollViews with content > scrollView).
+	if (_scrollView.contentOffset.y == 0) {
+		[_scrollView scrollRectToVisible:CGRectMake(0, 0, 1, 1) animated:YES];
+	}
+
 	// Tell the delegate
 	if ([self.delegate respondsToSelector:@selector(pullToRefreshView:didUpdateContentInset:)]) {
 		[self.delegate pullToRefreshView:self didUpdateContentInset:_scrollView.contentInset];


### PR DESCRIPTION
When the scrollView's content is larger than the scrollView itself and forcing reload with `[self.pullToRefreshView startLoadingAndExpand:YES]` the view is not expanded (setting the insets is not enough). This patch checks if the scrollView is at top and does the scrolling. I'm not sure that this is done the correct(tm) way, but I think it's the intended behavior.
