### PR TITLE
iOS 6 forbids dispatch_release() when using ARC.

### DIFF
--- a/SSPullToRefreshView.m
+++ b/SSPullToRefreshView.m
@@ -106,7 +106,9 @@
 - (void)dealloc {
 	self.scrollView = nil;
 	self.delegate = nil;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 60000
 	dispatch_release(_animationSemaphore);
+#endif
 }
 
 


### PR DESCRIPTION
dispatch_release() is forbidden for ARC–code in iOS 6 — removing it is safe.
