### PR TITLE
Got rid of unused NSDateComponents variable and unnecessary return on a void method

### DIFF
--- a/SSPullToRefreshDefaultContentView.m
+++ b/SSPullToRefreshDefaultContentView.m
@@ -79,9 +79,7 @@
         dateFormatter.dateStyle = NSDateFormatterLongStyle;
         dateFormatter.timeStyle = NSDateFormatterShortStyle;
 	});
-    NSDateComponents *components = [calendar components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit) 
-											   fromDate:self];
-	return [calendar dateFromComponents:components];
+
 	_lastUpdatedAtLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [dateFormatter stringForObjectValue:date]];
 }
 


### PR DESCRIPTION
[setLastUpdatedAt:withPullToRefreshView] method refers to a calendar variable which is never declared. Also, the method (a void) is incorrectly returning an NSDate.
