### PR TITLE
Add correct check for ARC support for GCD objects

### DIFF
--- a/SSPullToRefreshView.m
+++ b/SSPullToRefreshView.m
@@ -106,7 +106,7 @@
 - (void)dealloc {
 	self.scrollView = nil;
 	self.delegate = nil;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 60000
+#if !OS_OBJ_HAVE_OBJC
 	dispatch_release(_animationSemaphore);
 #endif
 }


### PR DESCRIPTION
The fix provided in https://github.com/soffes/sspulltorefresh/pull/16 is incorrect. As you can see in <os/object.h> (/usr/include/os/object.h), there's already a macro defined when objc support is available for GCD objects. Check for this instead. The previous way of doing it causes a memory leak when using ARC and a deployment target < iOS 6.0 because ARC support for GCD is only available after 6.0
