### PR TITLE
Fix typo in GCD ARC check macro

### DIFF
--- a/SSPullToRefreshView.m
+++ b/SSPullToRefreshView.m
@@ -106,7 +106,7 @@
 - (void)dealloc {
 	self.scrollView = nil;
 	self.delegate = nil;
-#if !OS_OBJ_HAVE_OBJC
+#if !OS_OBJECT_USE_OBJC
 	dispatch_release(_animationSemaphore);
 #endif
 }


### PR DESCRIPTION
Should be OS_OBJECT_USE_OBJC as seen in <os/object.h>
