### PR TITLE
Fixes issue where scrolling stutters

### DIFF
--- a/SSPullToRefreshView.m
+++ b/SSPullToRefreshView.m
@@ -316,7 +316,7 @@
 			if (y >= 0.0f) {
 				[self _setContentInsetTop:0.0f];
 			} else {
-				[self _setContentInsetTop:fminf(-y, _expandedHeight)];
+				[self _setContentInsetTop:_expandedHeight];
 			}
 		}
 		return;


### PR DESCRIPTION
Setting the contentInset while the UIScrollView is scrolling will make it stutter, and having it depend on the current contentOffset.y will trigger a lot of changes when the user is scrolling. 
This fix allows only two insets: 0 or _expandedHeight.
