### PR TITLE
Fixes scrolling issues when state is loading.

### DIFF
--- a/SSPullToRefresh/SSPullToRefreshView.m
+++ b/SSPullToRefresh/SSPullToRefreshView.m
@@ -314,11 +314,7 @@
 			}
 		// Scroll view is loading
 		} else if (_state == SSPullToRefreshViewStateLoading) {
-			if (y >= 0.0f) {
-				[self _setContentInsetTop:0.0f];
-			} else {
-				[self _setContentInsetTop:fminf(-y, _expandedHeight)];
-			}
+			[self _setContentInsetTop:_expandedHeight];
 		}
 		return;
 	}


### PR DESCRIPTION
The scrollView decelerates quickly when scrolled into _expandedHeight and state is loading. It also causes the scrollIndicators to jump around.

This fixes that issue by always making the pull-to-refresh view visible while it's loading, just like Mail/Twitter/Facebook etc. It will still not drop down unless specified.
