### PR TITLE
LastUpdatedAt not changed the timestamp after update finished

### DIFF
--- a/SSPullToRefresh/SSPullToRefreshView.m
+++ b/SSPullToRefresh/SSPullToRefreshView.m
@@ -199,6 +199,7 @@
 	[self _setState:SSPullToRefreshViewStateClosing animated:YES expanded:NO completion:^{
 		blockSelf.state = SSPullToRefreshViewStateNormal;
 	}];
+	[self refreshLastUpdatedAt];
 }
 
 


### PR DESCRIPTION
The LastUpdatedAt timestamp was not updating after the refresh finished...so i just called [self refreshLastUpdatedAt]; on - (void)finishLoading....
