### PR TITLE
Set background color of the pull to refresh view.

### DIFF
--- a/SSPullToRefresh/SSPullToRefreshView.m
+++ b/SSPullToRefresh/SSPullToRefreshView.m
@@ -88,6 +88,8 @@
 	[_contentView removeFromSuperview];
 	_contentView = contentView;
 	
+	self.backgroundColor = _contentView.backgroundColor;
+	
 	_contentView.autoresizingMask = UIViewAutoresizingNone;
 	[_contentView setState:_state withPullToRefreshView:self];
 	[self refreshLastUpdatedAt];


### PR DESCRIPTION
This pull request sets the background color of the SSPullToRefreshView to the same color of the content view. I think this is the expected behaviour. For example when your scroll view has a white background and you set the background color of your custom content view to grey and pull down the scroll view the color above the content view is still white:

![white](https://f.cloud.github.com/assets/540025/429674/4755e3ae-ae4d-11e2-9f2d-1260d868d4d6.png)
![correct](https://f.cloud.github.com/assets/540025/429673/45243e1e-ae4d-11e2-8bdd-36460753eae2.png)
