### PR TITLE
Allow autoresizing mask.

### DIFF
--- a/SSPullToRefresh/SSPullToRefreshView.m
+++ b/SSPullToRefresh/SSPullToRefreshView.m
@@ -88,7 +88,6 @@
 	[_contentView removeFromSuperview];
 	_contentView = contentView;
 	
-	_contentView.autoresizingMask = UIViewAutoresizingNone;
 	[_contentView setState:_state withPullToRefreshView:self];
 	[self refreshLastUpdatedAt];
 	[self addSubview:_contentView];


### PR DESCRIPTION
Is there a special reason why `UIViewAutoresizingNone` is set on the `contentView`? I'm finding myself having to do this:

```
self.pullToRefreshView.contentView = pullToRefreshContentView;
pullToRefreshContentView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
```
