### PR TITLE
Adjusts content inset calculation when loading to avoid floating section headers

### DIFF
--- a/SSPullToRefresh/SSPullToRefreshView.m
+++ b/SSPullToRefresh/SSPullToRefreshView.m
@@ -319,7 +319,8 @@
 			}
 		// Scroll view is loading
 		} else if (_state == SSPullToRefreshViewStateLoading) {
-			[self _setContentInsetTop:_expandedHeight];
+            CGFloat insetAdjustment = y < 0 ? fmaxf(0, _expandedHeight+y) : _expandedHeight;
+			[self _setContentInsetTop:_expandedHeight - insetAdjustment];
 		}
 		return;
 	}


### PR DESCRIPTION
This PR fixes #34 by adjusting the content inset calculation to take into account the current scroll position of the table.  Currently, section headers will just float 70pts down on the table as you scroll if the table is loading. 

[This SO Post](http://stackoverflow.com/questions/4365297/issue-scrolling-table-view-with-content-inset) has some photos of someone else experiencing the same impact.

I create a very basic [example project](https://github.com/grantjk/sspullexample) that you can quickly revert the changes in this PR to see the differences.
