### PR TITLE
Make sure the progress never exceeds 1.0

### DIFF
--- a/SSPullToRefresh/SSPullToRefreshView.m
+++ b/SSPullToRefresh/SSPullToRefreshView.m
@@ -308,7 +308,7 @@
 		// Scroll view is normal
 		} else if (self.state == SSPullToRefreshViewStateNormal) {
 			// Update the content view's pulling progressing
-			[self _setPullProgress:-y / self.expandedHeight];
+			[self _setPullProgress:fminf(-y / self.expandedHeight, 1.0f)];
 			
 			// Dragged enough to be ready
 			if (y < -self.expandedHeight) {


### PR DESCRIPTION
When driving an CAAnimation, CA is very picky with the timeOffset and doesn't accept values over 1.0.
Before, SSPullToRefreshView reported one value above 1.0 before changing to SSPullToRefreshViewStateReady.
