### PR TITLE
Adjusts documentation to accommodate -[UIViewController automaticallyAdjustsScrollViewInsets] + typo

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -8,9 +8,17 @@ If you're using SSPullToRefresh in your application, add it to [the list](https:
 ## Example Usage
 
 ``` objective-c
+// If automaticallyAdjustsScrollViewInsets is set to NO:
 - (void)viewDidLoad {
    [super viewDidLoad];
    self.pullToRefreshView = [[SSPullToRefreshView alloc] initWithScrollView:self.tableView delegate:self];
+}
+
+// If automaticallyAdjustsScrollViewInsets is set to YES:
+- (void)viewDidLayoutSubviews {
+   if(self.pullToRefreshView == nil) {
+      self.pullToRefreshView = [[SSPullToRefreshView alloc] initWithScrollView:self.tableView delegate:self];
+   }
 }
 
 - (void)viewDidUnload {

--- a/SSPullToRefresh/SSPullToRefreshView.h
+++ b/SSPullToRefresh/SSPullToRefreshView.h
@@ -9,9 +9,17 @@
 //
 // Example usage:
 //
+// // If automaticallyAdjustsScrollViewInsets is set to NO:
 // - (void)viewDidLoad {
 //    [super viewDidLoad];
 //    self.pullToRefreshView = [[SSPullToRefreshView alloc] initWithScrollView:self.tableView delegate:self];
+// }
+//
+// // If automaticallyAdjustsScrollViewInsets is set to YES:
+// - (void)viewDidLayoutSubviews {
+//    if(self.pullToRefreshView == nil) {
+//        self.pullToRefreshView = [[SSPullToRefreshView alloc] initWithScrollView:self.tableView delegate:self];
+//    }
 // }
 //
 // - (void)viewDidUnload {


### PR DESCRIPTION
Use of `-[UIViewController automaticallyAdjustsScrollViewInsets]` breaks SSPullToRefresh.

This is because UIKit does the automatic `contentInset` adjustment _after_ `viewDidLoad`. Instead, the inset adjustment is integrated into the `viewWillLayoutSubviews`/`viewDidLayoutSubviews` API flow.

The solution I came up with is to use `viewDidLayoutSubviews` to instantiate an `SSPullToRefreshView`, when using `automaticallyAdjustsScrollViewInsets`.

Also, minor typo. :)
