### PR TITLE
Take into account the contentinset.top when layouting the contentView

### DIFF
--- a/SSPullToRefresh/SSPullToRefreshView.m
+++ b/SSPullToRefresh/SSPullToRefreshView.m
@@ -142,7 +142,7 @@
 	contentFrame.size = contentSize;
 	switch (self.style) {
 		case SSPullToRefreshViewStyleScrolling:
-			contentFrame.origin.y = size.height - contentSize.height;
+			contentFrame.origin.y = size.height - contentSize.height - self.defaultContentInset.top;
 			break;
 		case SSPullToRefreshViewStyleStatic:
 			contentFrame.origin.y = size.height + self.defaultContentInset.top + self.scrollView.contentOffset.y;


### PR DESCRIPTION
If this is not done, the pull to refresh contentView is visible at the top of the actual scrollView content even when content offset. y = 0