### PR TITLE
Fix crash on iOS 7 due to rounding error

### DIFF
--- a/SSPullToRefresh/SSPullToRefreshView.m
+++ b/SSPullToRefresh/SSPullToRefreshView.m
@@ -387,7 +387,7 @@
 		// Scroll view is loading
 		} else if (self.state == SSPullToRefreshViewStateLoading) {
             CGFloat insetAdjustment = y < 0 ? fmaxf(0, self.expandedHeight + y) : self.expandedHeight;
-			[self _setContentInsetTop:self.expandedHeight - insetAdjustment];
+			[self _setContentInsetTop:roundf(self.expandedHeight - insetAdjustment)];
 		}
 		return;
 	} else if (self.scrollView.isDecelerating) {


### PR DESCRIPTION
This fixes a crash when using SSPullToRefreshView with a collection view on iOS 7. In [`SSPullToRefreshView.m:261`](https://github.com/soffes/sspulltorefresh/blob/08381d93e1df43fc876c4ff0f35da769cbb22d03/SSPullToRefresh/SSPullToRefreshView.m#L259), `inset` was set to `{0, 0, 0, 2.1997557e-36}`, which caused the pull to refresh control to incorrectly invalidate the layout and crash the app.